### PR TITLE
Remove packages/api/.env env vars, pointed prisma to apps/server/.env

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ pnpm install
 ```
 
 Then populate the following files:
+
 - apps/server/.env
 - apps/web/.env
 - packages/api/.env

--- a/packages/api/example.env
+++ b/packages/api/example.env
@@ -1,1 +1,0 @@
-DATABASE_URL=postgresql://test:test@localhost:5432/test?schema=public

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -15,8 +15,8 @@
     "dev": "tsc -w",
     "lint": "eslint \"src/**/*.ts*\"",
     "test": "jest",
-    "prisma:migrate": "prisma migrate dev --name init",
-    "prisma:generate": "prisma generate",
+    "prisma:migrate": "dotenv -e ../../apps/server/.env -- prisma migrate dev --name init",
+    "prisma:generate": "dotenv -e ../../apps/server/.env -- prisma generate",
     "postinstall": "pnpm run prisma:generate"
   },
   "jest": {
@@ -25,6 +25,7 @@
   "devDependencies": {
     "@types/jest": "^26.0.24",
     "@types/node": "^18.17.15",
+    "dotenv-cli": "^7.3.0",
     "eslint": "^7.32.0",
     "eslint-config-custom-server": "workspace:*",
     "jest": "^26.6.3",

--- a/packages/api/prisma/migrations/20230911095320_init/migration.sql
+++ b/packages/api/prisma/migrations/20230911095320_init/migration.sql
@@ -1,0 +1,10 @@
+/*
+  Warnings:
+
+  - You are about to alter the column `name` on the `User` table. The data in that column could be lost. The data in that column will be cast from `Text` to `VarChar(255)`.
+  - Made the column `name` on table `User` required. This step will fail if there are existing NULL values in that column.
+
+*/
+-- AlterTable
+ALTER TABLE "User" ALTER COLUMN "name" SET NOT NULL,
+ALTER COLUMN "name" SET DATA TYPE VARCHAR(255);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -212,6 +212,9 @@ importers:
       '@types/node':
         specifier: ^18.17.15
         version: 18.17.15
+      dotenv-cli:
+        specifier: ^7.3.0
+        version: 7.3.0
       eslint:
         specifier: ^7.32.0
         version: 7.32.0
@@ -2953,6 +2956,21 @@ packages:
     dependencies:
       webidl-conversions: 5.0.0
 
+  /dotenv-cli@7.3.0:
+    resolution: {integrity: sha512-314CA4TyK34YEJ6ntBf80eUY+t1XaFLyem1k9P0sX1gn30qThZ5qZr/ZwE318gEnzyYP9yj9HJk6SqwE0upkfw==}
+    hasBin: true
+    dependencies:
+      cross-spawn: 7.0.3
+      dotenv: 16.3.1
+      dotenv-expand: 10.0.0
+      minimist: 1.2.8
+    dev: true
+
+  /dotenv-expand@10.0.0:
+    resolution: {integrity: sha512-GopVGCpVS1UKH75VKHGuQFqS1Gusej0z4FyQkPdwjil2gNIv+LNsqBlboOzpJFZKVT95GkCyWJbBSdFEFUWI2A==}
+    engines: {node: '>=12'}
+    dev: true
+
   /dotenv@16.0.3:
     resolution: {integrity: sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==}
     engines: {node: '>=12'}
@@ -2961,7 +2979,6 @@ packages:
   /dotenv@16.3.1:
     resolution: {integrity: sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==}
     engines: {node: '>=12'}
-    dev: false
 
   /duplexer@0.1.2:
     resolution: {integrity: sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==}


### PR DESCRIPTION
This simplifies the env vars situation in this monorepo:

previously we had:
* apps/server/.env
* apps/web/.env
* packages/api/.env

now we only have:
* apps/server/.env
* apps/web/.env

