### PR TITLE
Unpin CD node version

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Use Node.js 18
         uses: actions/setup-node@v3
         with:
-          node-version: 18.16.1
+          node-version: 18
           cache: "pnpm"
 
       - name: Install dependencies
@@ -110,7 +110,7 @@ jobs:
       - name: Use Node.js 18
         uses: actions/setup-node@v3
         with:
-          node-version: 18.16.1
+          node-version: 18
           cache: "pnpm"
 
       - name: Install dependencies

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Use Node.js 18
         uses: actions/setup-node@v3
         with:
-          node-version: 18.16.1
+          node-version: 18
           cache: "pnpm"
 
       - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Use Node.js 18
         uses: actions/setup-node@v3
         with:
-          node-version: 18.16.1
+          node-version: 18
           cache: "pnpm"
 
       - name: Install dependencies


### PR DESCRIPTION
Speeds up CI and CD by using the GitHub-actions runners' built in node 18.18, avoiding the need to download it every run